### PR TITLE
Changes vlan.cpp and vlan.h

### DIFF
--- a/src/VLan.cpp
+++ b/src/VLan.cpp
@@ -214,6 +214,16 @@ bool VLan::deleteBridgeInterface(const string& bridgeIf)
             ifUp(filename);
             return false;
         }
+
+        // Ensure the bridge is correctly destroyed
+        if (existsBridge(bridgeIf))
+        {
+            if (!removeBridge(bridgeIf)) 
+            {
+              LOG("The %s cannot be destroyed. This can create consistency problems", bridgeIf.c_str());
+              return false;
+            }
+        }
     }
     else
     {
@@ -281,7 +291,7 @@ bool VLan::existsInterface(const string& interface)
 {
     ostringstream oss;
 
-    oss << ifconfig << " " << interface << " > /dev/null 2>/dev/null";
+    oss << ifconfig << " -a " << interface << " > /dev/null 2>/dev/null";
     oss.flush();
 
     return (executeCommand(oss.str()) == 0);
@@ -426,5 +436,15 @@ bool VLan::removeFile(const string& folder, const string& filename)
     }
 
     return true;
+}
+
+bool VLan::removeBridge(const string& bridgeIf)
+{
+
+    ostringstream command;
+    command << "/usr/sbin/brctl delbr " << bridgeIf;
+    command.flush();
+
+    return (executeCommand(command.str()) == 0);
 }
 

--- a/src/VLan.h
+++ b/src/VLan.h
@@ -61,6 +61,7 @@ class VLan: public Service
         /** Bridge related methods */
         bool createBridgeInterface(const string& bridgeIf);
         bool deleteBridgeInterface(const string& bridgeIf);
+	bool removeBridge(const string& bridgeIf);
         bool writeBridgeConfiguration(const string& device, const string& folder, const string& filename);
         string buildBridgeFilename(const string& bridgeIf);
 


### PR DESCRIPTION
I've created a new function on vlan.cpp, what checks if the bridge is existent after unconfiguring the vlan, and if is it, it destroys it. We have try it in a kvm, and it does fix the issue.
