### PR TITLE
Modified VLan.cpp to up the bridge if it exists

### DIFF
--- a/src/VLan.cpp
+++ b/src/VLan.cpp
@@ -128,6 +128,11 @@ bool VLan::createBridgeInterface(const string& bridgeIf)
     else
     {
         LOG("Bridge interface %s already exists.", bridgeIf.c_str());
+
+        ostringstream oss;
+        oss << ifconfig << " " << bridgeIf << " up" << " > /dev/null 2>/dev/null";
+        oss.flush();
+        return (executeCommand(oss.str()) == 0);
     }
 
     return true;


### PR DESCRIPTION
It's related with the last modification. Interoute has requested this modification. Basically, when aim deploy a virtualmachine, if the bridge exists, execute a ifconfig bridge up to ensure that the bridge is working correctly.
