### PR TITLE
Give more details about the AIM version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cproject
 .project
-src/*.o
+*.o
 src/aim
 *~
+version.c

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+The Abiquo Platform
+Cloud management application for hybrid clouds
+Copyright (C) 2008 - Abiquo Holdings S.L
+
+This application is free software; you can redistribute it and/or
+modify it under the terms of the GNU LESSER GENERAL PUBLIC
+LICENSE as published by the Free Software Foundation under
+version 3 of the License
+
+This software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+LESSER GENERAL PUBLIC LICENSE v.3 for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the
+Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+Boston, MA 02111-1307, USA.

--- a/src/AimServer.cpp
+++ b/src/AimServer.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
     }
 
     // Print aim's logo
-    PRINT_ASCII_LOGO(AIM_VERSION);
+    PRINT_ASCII_LOGO(aim_version);
 
     // Print configuration summary
     LOG("Configuration from '%s'", configFilename);
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
     printConfiguration(configuration);
 
     // Aim server initialization
-    LOG("Initializing AIM v%s", AIM_VERSION);
+    LOG("Initializing AIM v%s", aim_version);
     shared_ptr<TProcessor> processor(new AimProcessor(aimHandler));
     shared_ptr<TServerTransport> serverTransport(new TServerSocket(getIntProperty(configuration, serverPort)));
     shared_ptr<TTransportFactory> transportFactory(new TBufferedTransportFactory());
@@ -184,7 +184,8 @@ const char * parseArguments(int argc, char **argv, dictionary *d)
                 break;
 
             case 'v':
-                printf("AIM server version %s\n", AIM_VERSION);
+                printf("AIM server version %s\n", aim_version);
+                printf("  Git: %s\n  Build: %s\n  Platform: %s\n", git_revision, build_date, build_platform);
                 exit(EXIT_SUCCESS);
 
             default:

--- a/src/AimServer.h
+++ b/src/AimServer.h
@@ -22,7 +22,7 @@
 #ifndef AIMSERVER_H
 #define AIMSERVER_H
 
-#include <iniparser/dictionary.h>
+#include <dictionary.h>
 #include <getopt.h>
 
 #include <AimHandler.hpp>

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,8 +13,13 @@ GEN_SRC = aim_constants.cpp \
 		LibvirtService.cpp \
 		ExecUtils.cpp \
 		iniparser/dictionary.c \
-		iniparser/iniparser.c
-GEN_OBJ = $(GEN_SRC:%.cpp=%.o)
+		iniparser/iniparser.c \
+		version.c
+CPP_OBJ = $(GEN_SRC:%.cpp=%.o)
+GEN_OBJ = $(CPP_OBJ:%.c=%.o)
+
+# Force version generation in each build
+VERSION := $(shell sh gen-version.sh)
 
 # Include directories
 USR_INC = /usr/include
@@ -31,6 +36,8 @@ LD_PATH = -L/lib64 -L/usr/lib64 -L/usr/local/lib
 # Compiler and linker flags
 # https://issues.apache.org/jira/browse/THRIFT-1326
 THRIFT_FLAGS = -DHAVE_NETINET_IN_H -DHAVE_INTTYPES_H
+CC = g++
+CFLAGS = -Wall
 CXXFLAGS = -Wall $(THRIFT_FLAGS) $(INC_PATH)
 LDFLAGS = $(LD_PATH) -lpthread -lhiredis -lvirt -lthrift -lcurl -luuid -lboost_filesystem -lboost_thread-mt
 
@@ -38,10 +45,11 @@ LDFLAGS = $(LD_PATH) -lpthread -lhiredis -lvirt -lthrift -lcurl -luuid -lboost_f
 all: aim
 
 aim: $(GEN_OBJ)
-	$(CXX) -o $@ $^ $(LDFLAGS)
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:
 	$(RM) *.o aim
+	$(RM) iniparser/*.o
      
 .PHONY: all clean
 

--- a/src/gen-version.sh
+++ b/src/gen-version.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+AIM_VERSION=1.6.1
+
+GIT_REVISION=`git show-ref --head -s | head -n 1`
+BUILD_PLATFORM=`uname -srm`
+BUILD_DATE=`date +"%Y-%m-%d %H:%M"`
+
+LFILE=../LICENSE
+VFILE=version.c
+
+license() {
+    echo "/*" >$1
+    cat $LFILE | nl -b a -s ' * ' | cut -c7- >>$1
+    echo " */" >>$1
+    echo >>$1
+}
+
+license $VFILE
+echo '#include "version.h"' >>$VFILE
+echo >>$VFILE
+echo "const char* aim_version = \"$AIM_VERSION\";" >>$VFILE 
+echo "const char* git_revision = \"$GIT_REVISION\";" >>$VFILE 
+echo "const char* build_platform = \"$BUILD_PLATFORM\";" >>$VFILE 
+echo "const char* build_date = \"$BUILD_DATE\";" >>$VFILE 
+echo >>$VFILE

--- a/src/version.h
+++ b/src/version.h
@@ -18,6 +18,12 @@
  * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
  * Boston, MA 02111-1307, USA.
  */
-#ifndef AIM_VERSION
-#define AIM_VERSION "1.6.1"
+#ifndef __VERSION_H__
+#define __VERSION_H__
+
+extern const char* aim_version;
+extern const char* git_revision;
+extern const char* build_platform;
+extern const char* build_date;
+
 #endif


### PR DESCRIPTION
Every time the AIM is built, now a new `version.c` file will be dynamically generated, with the information of the environment where the AIM was built.

This will allow us to have a more precise control on the AIM versions that are deployed. Here is an example output:

```
# ./aim -v
AIM server version 1.6.1
  Git: defb12e6957fcc68632064696650a531a337a3bf
  Build: 2013-06-11 18:55
  Platform: Linux 2.6.32-358.6.2.el6.x86_64 x86_64
```

/cc @enricruiz @apuig @abelboldu 
