### PR TITLE
Skip git revision if source is not a git repository

### DIFF
--- a/src/gen-version.sh
+++ b/src/gen-version.sh
@@ -2,9 +2,15 @@
 
 AIM_VERSION=1.6.1
 
-GIT_REVISION=`git show-ref --head -s | head -n 1`
+
 BUILD_PLATFORM=`uname -srm`
 BUILD_DATE=`date +"%Y-%m-%d %H:%M"`
+
+if [ -d "../.git" ]; then
+    GIT_REVISION=`git show-ref --head -s | head -n 1`
+else
+    GIT_REVISION="N/A"
+fi
 
 LFILE=../LICENSE
 VFILE=version.c


### PR DESCRIPTION
The sources can be downloaded as a tarball or zip file from Github (there is no need to clone the repository). In this case, there is no Git information, so the Git revision can not be set.

This is what the Abiquo RPM builder does, so with this change, the Git revision will be skipped to let the build suceed.

/cc @abelboldu @enricruiz @apuig 
