### PR TITLE
5990: Properly undefine the domain

### DIFF
--- a/src/gen-version.sh
+++ b/src/gen-version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-AIM_VERSION=2.1.2
+AIM_VERSION=2.1.3
 
 
 BUILD_PLATFORM=`uname -srm`


### PR DESCRIPTION
If the domain has managed save images or snapshots, a regular call to undefine will fail. The appropriate flags must be set in order to properly undefine it.
